### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jwilger/caxton/compare/v0.1.2...v0.1.3) - 2025-08-06
+
+### Miscellaneous Tasks
+
+- remove Homebrew formula update from release workflow
+
 ## [0.1.2](https://github.com/jwilger/caxton/compare/v0.1.1...v0.1.2) - 2025-08-06
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caxton"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 authors = ["John Wilger <john.wilger@gmail.com>"]
 description = "A modern, efficient typesetting and document preparation system"


### PR DESCRIPTION



## 🤖 New release

* `caxton`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/jwilger/caxton/compare/v0.1.2...v0.1.3) - 2025-08-06

### Miscellaneous Tasks

- remove Homebrew formula update from release workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).