### PR TITLE
ci: move release-prepare/release-publish off self-hosted-gregor

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-prepare:
-    runs-on: [self-hosted, self-hosted-gregor]
+    runs-on: ubuntu-latest
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     permissions:
       contents: write
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --tags
-          release_plan="$(nix develop --command scripts/release plan --workspace .)"
+          release_plan="$(scripts/release plan --workspace .)"
           version="$(printf '%s\n' "$release_plan" | awk -F= '$1 == "version" { print $2 }')"
           release_type="$(printf '%s\n' "$release_plan" | awk -F= '$1 == "release_type" { print $2 }')"
           if [ -z "$version" ] || [ -z "$release_type" ]; then
@@ -55,7 +55,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.plan.outputs.version }}
         run: |
           set -euo pipefail
-          nix develop --command scripts/release prepare --workspace . --version "$RELEASE_VERSION" --date "$(date +%F)"
+          scripts/release prepare --workspace . --version "$RELEASE_VERSION" --date "$(date +%F)"
 
       - name: Check for release metadata changes
         id: diff

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release-publish:
-    runs-on: [self-hosted, self-hosted-gregor]
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && inputs.release_merge_sha != '' }}
     environment: release-publish
     permissions:


### PR DESCRIPTION
## Summary
- Switches `release-prepare.yml` and `release-publish.yml` from `runs-on: [self-hosted, self-hosted-gregor]` to `runs-on: ubuntu-latest`, matching `ci.yml`'s existing github-hosted setup, per the decision to deprioritize the self-hosted gregor runner for now.
- Drops the `nix develop --command` wrapper around the two `scripts/release` invocations in `release-prepare.yml`. That script only shells out to `python3` and `git` (no `mix`/Elixir/Erlang toolchain involved), both of which are preinstalled on github-hosted `ubuntu-latest` runners, so the nix shell (unavailable off gregor) is unnecessary there.
- `release-publish.yml` needed no other changes: it also doesn't invoke `mix`/Elixir/Erlang, and already installs its one extra dependency (`skopeo`) via `apt-get` in-workflow.
- Org-level secrets/vars (`CARGO_REGISTRY_TOKEN`, `RELEASE_SIGNING_KEY`, `GH_AUTOMATION_APP_ID`/`GH_AUTOMATION_APP_PRIVATE_KEY`, etc.) are unchanged and available identically on github-hosted runners.

No unrelated changes: `ci.yml` is untouched, and no other files were modified.

## Test plan
- [x] `actionlint` passes clean on both modified workflow files
- [x] YAML parses cleanly (js-yaml)
- [ ] CI checks on this PR go green on github-hosted runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release preparation workflow to run release planning and metadata generation directly from the repository environment.
  * Changed the release publishing job to use GitHub-hosted Ubuntu runners instead of a self-hosted runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->